### PR TITLE
Custom Fields and small typo fixes

### DIFF
--- a/benchmark_llm.py
+++ b/benchmark_llm.py
@@ -62,6 +62,7 @@ ANSWER_SYSTEM_PROMPT = CONFIG["reasoning"]["answer_system_prompt"]
 SINGLE_PHASE_TIMEOUT = CONFIG["timeouts"]["single_phase"]
 REASONING_PHASE_TIMEOUT = CONFIG["timeouts"]["reasoning_phase"]
 CONCURRENCY_LEVEL = CONFIG.get("concurrency_level", 1)  # Number of concurrent game rounds
+CUSTOM_FIELD_CONFIG = CONFIG["reasoning"].get("custom_field", {})  # Dynamic custom field configuration (Added for reasoning_effort)
 
 PRIZE_AMOUNTS = {
     1: "50€",
@@ -369,6 +370,10 @@ def get_single_phase_response(prompt, system_prompt, model_name):
         "top_p": TOP_P,
         "min_p": MIN_P,
     }
+    
+    # Add custom field if configured
+    if CUSTOM_FIELD_CONFIG and "field_name" in CUSTOM_FIELD_CONFIG and "field_value" in CUSTOM_FIELD_CONFIG:
+        data[CUSTOM_FIELD_CONFIG["field_name"]] = CUSTOM_FIELD_CONFIG["field_value"]
 
     # Add structured output support
     try:
@@ -422,6 +427,10 @@ def get_two_phase_response(prompt, model_name):
         "top_p": TOP_P,
         "min_p": MIN_P,
     }
+    
+    # Add custom field if configured
+    if CUSTOM_FIELD_CONFIG and "field_name" in CUSTOM_FIELD_CONFIG and "field_value" in CUSTOM_FIELD_CONFIG:
+        reasoning_data[CUSTOM_FIELD_CONFIG["field_name"]] = CUSTOM_FIELD_CONFIG["field_value"]
 
     reasoning_response = requests.post(
         LLM_SERVER_URL, json=reasoning_data, headers=headers, timeout=REASONING_PHASE_TIMEOUT
@@ -459,6 +468,10 @@ Now choose the final answer."""
         "top_p": TOP_P,
         "min_p": MIN_P,
     }
+    
+    # Add custom field if configured
+    if CUSTOM_FIELD_CONFIG and "field_name" in CUSTOM_FIELD_CONFIG and "field_value" in CUSTOM_FIELD_CONFIG:
+        answer_data[CUSTOM_FIELD_CONFIG["field_name"]] = CUSTOM_FIELD_CONFIG["field_value"]
 
     try:
         answer_data["response_format"] = {

--- a/config.json
+++ b/config.json
@@ -20,7 +20,14 @@
     "use_two_phase": false,
     "system_prompt": "Du bist ein Kandidat bei \"Wer wird Millionaer\" und musst Fragen auf Deutsch beantworten. Denke sorgfaeltig nach und waehle die beste Antwort aus den vier Optionen. Antworte NUR im JSON Format mit dem Schema: {\"answer\": \"X\"} wobei X einer der Buchstaben A, B, C oder D ist.",
     "reasoning_system_prompt": "Du bist ein Kandidat bei 'Wer wird Millionaer' und musst Fragen auf Deutsch beantworten. Analysiere die Frage sorgfaeltig und denke durch alle Aspekte durch. Du kannst so viel denken und schreiben wie du moechtest.",
-    "answer_system_prompt": "Basierend auf deiner vorherigen Analyse, waehle jetzt die finale Antwort. Antworte NUR im JSON Format mit dem Schema: {\"answer\": \"X\"} wobei X einer der Buchstaben A, B, C oder D ist."
+    "answer_system_prompt": "Basierend auf deiner vorherigen Analyse, waehle jetzt die finale Antwort. Antworte NUR im JSON Format mit dem Schema: {\"answer\": \"X\"} wobei X einer der Buchstaben A, B, C oder D ist.",
+    "custom_field": {
+      "field_name": "reasoning",
+      "field_value": {
+        "effort": "high",
+        "summary": "auto"
+      }
+    }
   },
   "concurrency_level": 1
 }

--- a/fragen_antworten.json
+++ b/fragen_antworten.json
@@ -1312,7 +1312,7 @@
 ],
 [
 "Wo 'sieht oft alles ganz anders aus'?",
-"in der Kanlei",
+"in der Kanzlei",
 "in der Werkstatt",
 "in der Praxis",
 "in der Kantine",

--- a/fragen_antworten.json
+++ b/fragen_antworten.json
@@ -1829,7 +1829,7 @@
 "Samstag",
 "Sonntag",
 "Montag",
-"Diensta",
+"Dienstag",
 "Sonntag"
 ],
 [

--- a/fragen_antworten.json
+++ b/fragen_antworten.json
@@ -1854,7 +1854,7 @@
 "Welche Plattform hat Donald Trump in den USA verboten?",
 "TikTok",
 "Youtube",
-"Instagramm",
+"Instagram",
 "Snapchat",
 "TikTok"
 ],


### PR DESCRIPTION
Some models like gpt-oss and seed-oss have custom fields to control paramters like the reasoning effort or the thinking budget. This commits adds that feature to the config.
Also patches a small typos in the questions.